### PR TITLE
[IMP] oca-port: show commits when confirming porting

### DIFF
--- a/tools/oca_port/misc.py
+++ b/tools/oca_port/misc.py
@@ -230,6 +230,25 @@ class PullRequest(abc.Hashable):
     def paths_not_ported(self):
         return list(self.paths - self.ported_paths)
 
+    def to_string(self, commits, bc, verbose=False):
+        lines_to_print = [""]
+        if self.number:
+            lines_to_print.append(
+                f"{bc.BOLD}{bc.OKCYAN}PR #{self.number}{bc.END} "
+                f"({self.url}) {bc.OKCYAN}{self.title}{bc.ENDC}"
+            )
+        else:
+            lines_to_print.append(
+                f"{bc.BOLD}{bc.OKCYAN}Commits w/o PR{bc.END}"
+            )
+        if verbose or not self.number:
+            for commit in commits:
+                lines_to_print.append(
+                    f"\t\t{bc.DIM}{commit.hexsha[:8]} "
+                    f"{commit.summary}{bc.ENDD}"
+                )
+        return "\n".join(lines_to_print)
+
 
 class InputStorage():
     """Store the user inputs related to an addon.

--- a/tools/oca_port/misc.py
+++ b/tools/oca_port/misc.py
@@ -332,19 +332,22 @@ def clean_text(text):
     return re.sub(r"\[.*\]|\d+\.\d+", "", text).strip()
 
 
+def _full_url(url):
+    return "/".join([GITHUB_API_URL, url])
+
+
 def _request_github(url, method="get", params=None, json=None):
     """Request GitHub API."""
     headers = {"Accept": "application/vnd.github.groot-preview+json"}
     if os.environ.get("GITHUB_TOKEN"):
         token = os.environ.get("GITHUB_TOKEN")
         headers.update({"Authorization": f"token {token}"})
-    full_url = "/".join([GITHUB_API_URL, url])
     kwargs = {"headers": headers}
     if json:
         kwargs.update(json=json)
     if params:
         kwargs.update(params=params)
-    response = getattr(requests, method)(full_url, **kwargs)
+    response = getattr(requests, method)(_full_url(url), **kwargs)
     if not response.ok:
         raise RuntimeError(response.text)
     return response.json()

--- a/tools/oca_port/port_addon_pr.py
+++ b/tools/oca_port/port_addon_pr.py
@@ -146,13 +146,7 @@ class PortAddonPullRequest():
             self, pr, commits, base_ref, previous_pr=None, previous_pr_branch=None,
             ):
         """Port commits of a Pull Request in a new branch."""
-        if pr.number:
-            print(
-                f"- {bc.BOLD}{bc.OKCYAN}Port PR #{pr.number}{bc.END} "
-                f"({pr.url}) {bc.OKCYAN}{pr.title}{bc.ENDC}..."
-            )
-        else:
-            print(f"- {bc.BOLD}{bc.OKCYAN}Port commits w/o PR{bc.END}...")
+        print(pr.to_string(commits, bc, self.verbose))
         based_on_previous = False
         # Ensure to not start to work from a working branch
         if self.to_branch.name in self.repo.heads:


### PR DESCRIPTION
* After long list of PR, confirming porting does not have commit numbers so developer need to scroll back to get the numbers. This is to have commit numbers right at confirming message so that developer can quickly check the commits.
* When porting some modules (i.e. `stock_vertical_lift_server_env`), github api return two PR for one commit (https://api.github.com/repos/OCA/stock-logistics-warehouse/commits/3711267c4f04aade436be158a565fcef1b9fc4b3/pulls). Only one PR has the commit (#797). The other PR (#1020) doesn't change the module being ported.